### PR TITLE
feat: outputting literal step text as steps as executed when using verbose go test output

### DIFF
--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ tests. `Runner.ShortTags` method can be used to select a set of tags to
 * `Before()`, `After()`, `BeforeStep()`, or and `AfterStep()` can be used to register custom hooks.
 * `Tags` and `ShortTags` can be used with tag expressions as described above.
 * `NonParallel()` disables parallel tests.
-* `--verbose` or `-v` in your go-tests will emit the current test step definition to stdout while your tests are running, this is useful for testing
+* `--verbose` or `-v` with `go test` will emit the current test step definition to stdout while your tests are running, this is useful for debugging failing tests.
 
 ### Property-based testing using Rapid
 

--- a/README.md
+++ b/README.md
@@ -190,6 +190,7 @@ tests. `Runner.ShortTags` method can be used to select a set of tags to
 * `Before()`, `After()`, `BeforeStep()`, or and `AfterStep()` can be used to register custom hooks.
 * `Tags` and `ShortTags` can be used with tag expressions as described above.
 * `NonParallel()` disables parallel tests.
+* `--verbose` or `-v` in your go-tests will emit the current test step definition to stdout while your tests are running, this is useful for testing
 
 ### Property-based testing using Rapid
 

--- a/run_doc.go
+++ b/run_doc.go
@@ -31,7 +31,7 @@ func (r *docRunner) runDoc(t *testing.T) {
 				t.Parallel()
 			}
 
-			r.runScenario(t, pickle)
+			r.runScenario(t, pickle, testing.Verbose())
 		})
 	}
 }

--- a/run_scenario.go
+++ b/run_scenario.go
@@ -10,7 +10,7 @@ import (
 	"github.com/regen-network/gocuke/internal/tag"
 )
 
-func (r *docRunner) runScenario(t *testing.T, pickle *messages.Pickle) {
+func (r *docRunner) runScenario(t *testing.T, pickle *messages.Pickle, verbose bool) {
 	t.Helper()
 
 	tags := tag.NewTagsFromPickleTags(pickle.Tags)
@@ -57,6 +57,7 @@ func (r *docRunner) runScenario(t *testing.T, pickle *messages.Pickle) {
 				t:         t,
 				pickle:    pickle,
 				stepDefs:  stepDefs,
+				verbose:   verbose,
 			}).runTestCase()
 		})
 	} else {
@@ -65,6 +66,7 @@ func (r *docRunner) runScenario(t *testing.T, pickle *messages.Pickle) {
 			t:         t,
 			pickle:    pickle,
 			stepDefs:  stepDefs,
+			verbose:   verbose,
 		}).runTestCase()
 	}
 }
@@ -76,6 +78,7 @@ type scenarioRunner struct {
 	pickle   *messages.Pickle
 	stepDefs []*stepDef
 	step     *messages.PickleStep
+	verbose  bool
 }
 
 func (r *scenarioRunner) runTestCase() {

--- a/run_step.go
+++ b/run_step.go
@@ -96,5 +96,9 @@ func (r *scenarioRunner) runStep(step *messages.PickleStep, def *stepDef) {
 		}
 	}
 
+	if r.verbose {
+		r.t.Logf("Step: %s", step.Text)
+	}
+
 	def.theFunc.Call(values)
 }


### PR DESCRIPTION
Implements:
- https://github.com/regen-network/gocuke/issues/7