### PR TITLE
feat: added support for types assignable to special step argument types

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -112,10 +112,13 @@ func (r *Runner) registerSuite(suiteType interface{}) *Runner {
 			continue
 		}
 
-		if getter, ok := r.supportedSpecialArgs[field.Type]; ok {
-			r.suiteInjectors = append(r.suiteInjectors, &suiteInjector{getValue: getter, field: field})
-			if field.Type == rapidTType {
-				r.suiteUsesRapid = true
+		for specialArgType, getter := range r.supportedSpecialArgs {
+			if field.Type.AssignableTo(specialArgType) {
+				r.suiteInjectors = append(r.suiteInjectors, &suiteInjector{getValue: getter, field: field})
+				if field.Type == rapidTType {
+					r.suiteUsesRapid = true
+				}
+				break
 			}
 		}
 	}

--- a/simple_test.go
+++ b/simple_test.go
@@ -53,3 +53,51 @@ func (s simpleSuiteNP) IHaveLeft(a int64) {
 		s.Fatalf("expected %d cukes, have %d", a, globalCukes)
 	}
 }
+
+// test a struct using a different interface compatible with gocuke.TestingT
+func TestSimpleCompat(t *testing.T) {
+	gocuke.NewRunner(t, &simpleSuiteCompat{}).Path("examples/simple/simple.feature").Run()
+}
+
+type TestingTCompat interface {
+	Cleanup(func())
+	Error(args ...interface{})
+	Errorf(format string, args ...interface{})
+	Fail()
+	FailNow()
+	Failed() bool
+	Fatal(args ...interface{})
+	Fatalf(format string, args ...interface{})
+	Log(args ...interface{})
+	Logf(format string, args ...interface{})
+	Skip(args ...interface{})
+	SkipNow()
+	Skipf(format string, args ...interface{})
+	Helper()
+
+	// Not included in gocuke.TestingT
+	Name() string
+}
+
+type simpleSuiteCompat struct {
+	TestingTCompat
+	cukes int64
+}
+
+func (s *simpleSuiteCompat) IHaveCukes(a int64) {
+	// These calls to s.LogF fail if s.TestingTCompat is nil
+	s.Logf("I have %d cukes", a)
+	s.cukes = a
+}
+
+func (s *simpleSuiteCompat) IEat(a int64) {
+	s.Logf("I eat %d", a)
+	s.cukes -= a
+}
+
+func (s *simpleSuiteCompat) IHaveLeft(a int64) {
+	s.Logf("I have %d left?", a)
+	if a != s.cukes {
+		s.Fatalf("expected %d cukes, have %d", a, s.cukes)
+	}
+}


### PR DESCRIPTION
This update adds support for injecting special step arguments whose types are assignable to the 4 supported types (in contrast to supporting only arguments whose types are precisely those 4).

### Background use case: Terratest
I wanted to use gocuke with [Terratest](https://github.com/gruntwork-io/terratest).  Injecting a `gocuke.TestingT` into my suite didn't provide the `Name()` method required by Terratest:

`./gocuke_test.go:51:25: cannot use s (variable of type *suite) as "github.com/gruntwork-io/terratest/modules/testing".TestingT value in argument to terraform.InitAndApply: *suite does not implement "github.com/gruntwork-io/terratest/modules/testing".TestingT (missing method Name)`

I added `Name()` to a custom interface that includes all the methods in `gocuke.TestingT`.  But this was not injected via the special step arguments.

My solution was to modify this behavior in `runner.go` to inject based on assignability instead of equality.