### PR TITLE
feat: output suggestions in the order steps were defined

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,6 +77,10 @@ type suite struct {
 When you run the tests, they should fail and suggest that you add these
 step definitions:
 ```go
+func (s *suite) IHaveCukes(a int64) {
+    panic("PENDING")
+}
+
 func (s *suite) IEat(a int64) {
     panic("PENDING")
 }
@@ -85,14 +89,10 @@ func (s *suite) IHaveLeft(a int64) {
     panic("PENDING")
 }
 
-func (s *suite) IHaveCukes(a int64) {
-    panic("PENDING")
-}
-
 Steps can be manually registered with the runner for customization using this code:
-  Step(`^I\s+have\s+(-?\d+)\s+cukes$`, (*simpleSuite).IHaveCukes).
-  Step(`^I\s+eat\s+(-?\d+)$`, (*simpleSuite).IEat).
-  Step(`^I\s+have\s+(-?\d+)\s+left$`, (*simpleSuite).IHaveLeft)
+  Step(`^I\s+have\s+(-?\d+)\s+cukes$`, (*suite).IHaveCukes).
+  Step(`^I\s+eat\s+(-?\d+)$`, (*suite).IEat).
+  Step(`^I\s+have\s+(-?\d+)\s+left$`, (*suite).IHaveLeft)
 ```
 
 Copy these definitions into `simple_test.go`.

--- a/find_step.go
+++ b/find_step.go
@@ -22,7 +22,10 @@ func (r *Runner) findStep(t *testing.T, step *messages.PickleStep) *stepDef {
 		return r.addStepDef(t, sig.regex, method.Func)
 	}
 
-	r.suggestions[sig.name] = sig
+	if !r.haveSuggestion[sig.name] {
+		r.haveSuggestion[sig.name] = true
+		r.suggestions = append(r.suggestions, sig)
+	}
 	t.Errorf("can't find step definition for: %s", step.Text)
 
 	return nil

--- a/runner.go
+++ b/runner.go
@@ -17,7 +17,8 @@ type Runner struct {
 	paths                []string
 	parallel             bool
 	stepDefs             []*stepDef
-	suggestions          map[string]methodSig
+	haveSuggestion       map[string]bool
+	suggestions          []methodSig
 	supportedSpecialArgs map[reflect.Type]specialArgGetter
 	suiteInjectors       []*suiteInjector
 	beforeHooks          []*stepDef
@@ -56,10 +57,10 @@ func NewRunner(t *testing.T, suiteType interface{}) *Runner {
 	initGlobalTagExpr()
 
 	r := &Runner{
-		topLevelT:   t,
-		incr:        &messages.Incrementing{},
-		parallel:    false,
-		suggestions: map[string]methodSig{},
+		topLevelT:      t,
+		incr:           &messages.Incrementing{},
+		parallel:       false,
+		haveSuggestion: map[string]bool{},
 		supportedSpecialArgs: map[reflect.Type]specialArgGetter{
 			// TestingT
 			reflect.TypeOf((*TestingT)(nil)).Elem(): func(runner *scenarioRunner) interface{} {


### PR DESCRIPTION
When using gocuke with new feature files, I've found that it sometimes outputs step suggestions in an illogical order. This is because under the hood suggestions are stored in a map instead of an array. This PR creates converts that code to use an array so that suggestions get outputted in the same order as they were declared in the feature file.