### PR TITLE
fix issue #34

### DIFF
--- a/runner.go
+++ b/runner.go
@@ -2,6 +2,7 @@ package gocuke
 
 import (
 	"reflect"
+	"sync"
 	"testing"
 
 	messages "github.com/cucumber/messages/go/v22"
@@ -17,6 +18,7 @@ type Runner struct {
 	paths                []string
 	parallel             bool
 	stepDefs             []*stepDef
+	stepDefsMutex 	  	 *sync.RWMutex
 	haveSuggestion       map[string]bool
 	suggestions          []methodSig
 	supportedSpecialArgs map[reflect.Type]specialArgGetter
@@ -84,6 +86,7 @@ func NewRunner(t *testing.T, suiteType interface{}) *Runner {
 			},
 		},
 		suiteUsesRapid: false,
+		stepDefsMutex: &sync.RWMutex{},
 	}
 
 	r.registerSuite(suiteType)

--- a/simple_test.go
+++ b/simple_test.go
@@ -34,7 +34,6 @@ func TestSimpleNonPointer(t *testing.T) {
 	gocuke.
 		NewRunner(t, simpleSuiteNP{}).
 		Path("examples/simple/simple.feature").
-		NonParallel().
 		Run()
 }
 

--- a/step_def.go
+++ b/step_def.go
@@ -54,7 +54,9 @@ func (r *Runner) Step(step interface{}, definition interface{}) *Runner {
 
 func (r *Runner) addStepDef(t *testing.T, exp *regexp.Regexp, definition reflect.Value) *stepDef {
 	t.Helper()
+	defer r.stepDefsMutex.Unlock()
 
+	r.stepDefsMutex.Lock()
 	def := r.newStepDefOrHook(t, exp, definition)
 	r.stepDefs = append(r.stepDefs, def)
 	return def


### PR DESCRIPTION
Add stepDefs mutex and lock in appropriate places to prevent races. 

Enables a test to be switched back to use the default parallel = true flag, the example api and hooks tests still fail with parallelization, but after looking it seems that's an issue with how they were written (using package global variables) rather than a bug with concurrent execution.

#34 