### PR TITLE
fix: return nil when HeaderTable.Get does not find a corresponding header

### DIFF
--- a/datatable.go
+++ b/datatable.go
@@ -91,9 +91,14 @@ type HeaderTable struct {
 }
 
 // Get returns the cell at the provided row offset (skipping the header row)
-// and column name (as indicated in the header).
+// and column name (as indicated in the header). If the column name is not
+// found, nil is returned.
 func (h *HeaderTable) Get(row int, col string) *Cell {
-	return h.DataTable.Cell(row+1, h.headers[col])
+	if v, ok := h.headers[col]; !ok {
+		return nil
+	} else {
+		return h.DataTable.Cell(row+1, v)
+	}
 }
 
 // NumRows returns the number of rows in the table (excluding the header row).


### PR DESCRIPTION
With a datatable like this:
```
| example_header |
| example_value |
```

Before this commit, if you call `dt.HeaderTable().Get(0, "this_does_not_exist")`, it returns the cell at `1,0` position in the datatable (i.e. `example_value`).

After this commit, if you call `dt.HeaderTable().Get(0, "this_does_not_exist")`, it returns `nil`. 